### PR TITLE
fix(security): bump lodash to ^4.18.0 (GHSA-f23m-r3pf-42rh, GHSA-r5fr-rjxr-66jc, ENG-14276)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2456,9 +2456,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     },
     "flatted": "^3.4.2",
     "path-to-regexp": "^8.4.0",
-    "picomatch": "^4.0.4"
+    "picomatch": "^4.0.4",
+    "lodash": "^4.18.0"
   },
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Summary

| Package | Old | New | Advisory | CVSS | Status |
|---------|-----|-----|----------|------|--------|
| lodash | 4.17.23 | 4.18.1 | GHSA-f23m-r3pf-42rh | 6.5 | ✅ Fixed |
| lodash | 4.17.23 | 4.18.1 | GHSA-r5fr-rjxr-66jc | 8.1 | ✅ Fixed |

lodash is a dev-only transitive dep pulled in by `@trivago/prettier-plugin-sort-imports`. Added `"lodash": "^4.18.0"` override. Lock resolves to `4.18.1`.

<details>
<summary>Changelog impact summary</summary>

| Package | Old | New | Classification | Key changes |
|---------|-----|-----|----------------|-------------|
| lodash | 4.17.23 | 4.18.1 | Security | Prototype pollution + code injection fixes; dev dep only, no production impact |

</details>