### PR TITLE
fix(security): bump hono 4.12.12 → 4.12.14 (ENG-14665)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2177,9 +2177,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "path-to-regexp": "^8.4.0",
     "picomatch": "^4.0.4",
     "lodash": "^4.18.0",
-    "hono": "^4.12.12",
+    "hono": "^4.12.14",
     "@hono/node-server": "^1.19.13"
   },
   "keywords": [


### PR DESCRIPTION
## Vulnerability Fixes

| Package | Old | New | Advisory | CVSS | Status |
|---------|-----|-----|----------|------|--------|
| hono | 4.12.12 | 4.12.14 | GHSA-458j-xx4x-4375 | 5.4 | ✅ Fixed |

## Tickets
- ENG-14665 (GHSA-458j-xx4x-4375, MEDIUM) — hono JSX attribute injection: improper handling of JSX attribute names allows malformed keys to corrupt generated HTML output (XSS risk)

## Change
Bumped `"hono": "^4.12.12"` → `"^4.12.14"` in `overrides` and regenerated `package-lock.json`.

<details>
<summary>Changelog impact summary</summary>

| Package | Old | New | Classification | Key changes |
|---------|-----|-----|----------------|-------------|
| hono | 4.12.12 | 4.12.14 | Patch/security | JSX attribute name sanitization fix; no API changes |

</details>