### PR TITLE
INF-1650: run agentql-mcp container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,10 @@ RUN npm run build
 # Environment variables
 ENV AGENTQL_API_KEY=your-api-key
 
+# Drop root: the node base image ships a non-privileged `node` user (uid 1000).
+# The build artifacts under /app are world-readable, so the runtime only needs
+# read access — no chown required.
+USER node
+
 # Command will be provided by smithery.yaml
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## What

Clears the Semgrep finding `dockerfile.security.missing-user.missing-user` (ERROR) at `Dockerfile:21` from the fresh org-wide SAST scan (INF-1650). The container had no `USER` instruction, so the MCP server ran as root.

## How

Add `USER node` before `CMD`. The `node:20-alpine` base image ships a non-privileged `node` user (uid 1000); the build artifacts under `/app` are world-readable, so the runtime needs only read access — no `chown` required.

## Verification

- Before: `semgrep --config p/dockerfile` → 1 finding (`missing-user`)
- After: → **0 findings**
- `npm run build` / `npm run lint` (the repo CI) are unaffected — the change only adds a runtime `USER`.

Closes INF-1650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)